### PR TITLE
Adds support for midigrid if installed

### DIFF
--- a/torii.lua
+++ b/torii.lua
@@ -61,6 +61,7 @@ local running = true
 local ledlevels = {1,3,5,7,10,15} 
 -- local ledlevels = {15,15,15,15,15,15} -- use this for monobright grids.
 
+local grid = util.file_exists(_path.code.."midigrid") and include "midigrid/lib/mg_128" or grid
 local grds = {}
 local grid_device
 local grid_w = 0


### PR DESCRIPTION
I'm new to Lua, so not 100% sure this will fail gracefully in all cases. I have a LP mini MK3 and it works as expected with the Midigrid library installed and correctly ignores the LP if Midigrid is not installed. Since I don't own a Monome Grid, I can't confirm that it works in both cases, but the logic suggests it will.